### PR TITLE
ADD Docker file to directly start the REPL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM clojure
+WORKDIR /opt
+
+RUN wget https://github.com/dmoranj/qbitos/archive/master.zip
+RUN unzip master.zip
+
+WORKDIR /opt/qbitos-master
+RUN lein deps && lein compile && lein install
+
+ENTRYPOINT lein repl
+


### PR DESCRIPTION
Add Docker to directly start the REPL with the loaded libraries.
