### PR TITLE
Remove template function

### DIFF
--- a/src/qbitos/core.clj
+++ b/src/qbitos/core.clj
@@ -7,7 +7,7 @@
 (use 'qbitos.complex)
 
 (defn -main
-  "I don't do a whole lot ... yet."
+  "Main entry point"
   [& args]
-  (println "Hello, World!"))
+  '())
 


### PR DESCRIPTION
The `-main` function is still the same as created by the `lein new` command. This is just a cosmetic change in order to have an empty function. If this project is intended as a library, then maybe it does not need a `main` namespace at all.

```
❯ lein test

lein test qbitos.classical-test

lein test qbitos.core-test

Ran 18 tests containing 31 assertions.
0 failures, 0 errors.
```
